### PR TITLE
fix: auto-activate venv in start_ui.sh

### DIFF
--- a/start_ui.sh
+++ b/start_ui.sh
@@ -11,8 +11,12 @@ echo ""
 # Get the directory where this script is located
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# Use virtual environment if it exists
+if [ -f "$SCRIPT_DIR/venv/bin/activate" ]; then
+    source "$SCRIPT_DIR/venv/bin/activate"
+    PYTHON_CMD="python"
 # Check if Python is available
-if ! command -v python3 &> /dev/null; then
+elif ! command -v python3 &> /dev/null; then
     if ! command -v python &> /dev/null; then
         echo "ERROR: Python not found"
         echo "Please install Python from https://python.org"


### PR DESCRIPTION
## Summary
- Fixed `start_ui.sh` to auto-activate the virtual environment when it exists
- Aligns behavior with `start.sh` which already handles venv activation

## Problem
When running `./start_ui.sh` after setting up a venv, users get:
```
ModuleNotFoundError: No module named 'dotenv'
```

The script was using the system Python (which may not have dependencies installed) instead of the venv Python.

## Solution
Added venv detection and activation logic before running `start_ui.py`:
```bash
if [ -f "$SCRIPT_DIR/venv/bin/activate" ]; then
    source "$SCRIPT_DIR/venv/bin/activate"
    PYTHON_CMD="python"
```

## Test plan
- [x] Tested on macOS with Python 3.12 venv
- [x] Verified `./start_ui.sh` now works without manually activating venv