### PR TITLE
fix: make boolean fields resilient to NULL values

### DIFF
--- a/mcp_server/feature_mcp.py
+++ b/mcp_server/feature_mcp.py
@@ -409,6 +409,7 @@ def feature_create_bulk(
                     description=feature_data["description"],
                     steps=feature_data["steps"],
                     passes=False,
+                    in_progress=False,
                 )
                 session.add(db_feature)
                 created_count += 1
@@ -459,6 +460,7 @@ def feature_create(
                 description=description,
                 steps=steps,
                 passes=False,
+                in_progress=False,
             )
             session.add(db_feature)
             session.commit()

--- a/server/routers/features.py
+++ b/server/routers/features.py
@@ -72,7 +72,10 @@ def get_db_session(project_dir: Path):
 
 
 def feature_to_response(f) -> FeatureResponse:
-    """Convert a Feature model to a FeatureResponse."""
+    """Convert a Feature model to a FeatureResponse.
+
+    Handles legacy NULL values in boolean fields by treating them as False.
+    """
     return FeatureResponse(
         id=f.id,
         priority=f.priority,
@@ -80,8 +83,9 @@ def feature_to_response(f) -> FeatureResponse:
         name=f.name,
         description=f.description,
         steps=f.steps if isinstance(f.steps, list) else [],
-        passes=f.passes,
-        in_progress=f.in_progress,
+        # Handle legacy NULL values gracefully - treat as False
+        passes=f.passes if f.passes is not None else False,
+        in_progress=f.in_progress if f.in_progress is not None else False,
     )
 
 


### PR DESCRIPTION
## Summary

Features with NULL values in `passes` or `in_progress` fields caused Pydantic validation errors (`Input should be a valid boolean`) in the API, breaking the UI.

## Root Cause

- Boolean columns allowed NULL values
- Some features ended up with NULL instead of False
- Pydantic's `FeatureResponse` model required actual booleans

## Solution - Defense in Depth

| Layer | Fix |
|-------|-----|
| Database model | Add `nullable=False` to `passes` and `in_progress` columns |
| Migration | Auto-fix existing NULL values to False on database connect |
| API layer | Handle NULL gracefully in `feature_to_response` (treat as False) |
| MCP server | Explicitly set `in_progress=False` when creating features |

## Changes

- `api/database.py`: Added `nullable=False`, NULL handling in `to_dict()`, and migration function
- `server/routers/features.py`: Added NULL handling in `feature_to_response()`
- `mcp_server/feature_mcp.py`: Explicitly set `in_progress=False` in `feature_create` and `feature_create_bulk`

## Test plan

- [x] Verified NULL values in database are auto-fixed on connect
- [ ] Verify API returns proper boolean values
- [ ] Verify new features are created with proper boolean defaults

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed data consistency by ensuring boolean feature fields are properly initialized and stored with non-null values throughout the database.
  * Implemented automatic correction for existing records with missing values to maintain reliable data integrity across the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->