### PR TITLE
fix: use ANTHROPIC_DEFAULT_OPUS_MODEL env var for model selection

### DIFF
--- a/server/services/assistant_chat_session.py
+++ b/server/services/assistant_chat_session.py
@@ -255,10 +255,14 @@ class AssistantChatSession:
         # Build environment overrides for API configuration
         sdk_env = {var: os.getenv(var) for var in API_ENV_VARS if os.getenv(var)}
 
+        # Determine model from environment or use default
+        # This allows using alternative APIs (e.g., GLM via z.ai) that may not support Claude model names
+        model = os.getenv("ANTHROPIC_DEFAULT_OPUS_MODEL", "claude-opus-4-5-20251101")
+
         try:
             self.client = ClaudeSDKClient(
                 options=ClaudeAgentOptions(
-                    model="claude-opus-4-5-20251101",
+                    model=model,
                     cli_path=system_cli,
                     # System prompt loaded from CLAUDE.md via setting_sources
                     # This avoids Windows command line length limit (~8191 chars)

--- a/server/services/expand_chat_session.py
+++ b/server/services/expand_chat_session.py
@@ -167,11 +167,15 @@ class ExpandChatSession:
         # Build environment overrides for API configuration
         sdk_env = {var: os.getenv(var) for var in API_ENV_VARS if os.getenv(var)}
 
+        # Determine model from environment or use default
+        # This allows using alternative APIs (e.g., GLM via z.ai) that may not support Claude model names
+        model = os.getenv("ANTHROPIC_DEFAULT_OPUS_MODEL", "claude-opus-4-5-20251101")
+
         # Create Claude SDK client
         try:
             self.client = ClaudeSDKClient(
                 options=ClaudeAgentOptions(
-                    model="claude-opus-4-5-20251101",
+                    model=model,
                     cli_path=system_cli,
                     system_prompt=system_prompt,
                     allowed_tools=[

--- a/server/services/spec_chat_session.py
+++ b/server/services/spec_chat_session.py
@@ -169,10 +169,14 @@ class SpecChatSession:
         # Build environment overrides for API configuration
         sdk_env = {var: os.getenv(var) for var in API_ENV_VARS if os.getenv(var)}
 
+        # Determine model from environment or use default
+        # This allows using alternative APIs (e.g., GLM via z.ai) that may not support Claude model names
+        model = os.getenv("ANTHROPIC_DEFAULT_OPUS_MODEL", "claude-opus-4-5-20251101")
+
         try:
             self.client = ClaudeSDKClient(
                 options=ClaudeAgentOptions(
-                    model="claude-opus-4-5-20251101",
+                    model=model,
                     cli_path=system_cli,
                     # System prompt loaded from CLAUDE.md via setting_sources
                     # This avoids Windows command line length limit (~8191 chars)


### PR DESCRIPTION
## Summary
- Fixed hardcoded model in chat session services that ignored `ANTHROPIC_DEFAULT_OPUS_MODEL` environment variable
- Now reads model from env var with fallback to default `claude-opus-4-5-20251101`
- Enables alternative API providers (e.g., GLM via z.ai, synthetic.new) to work correctly

## Changes
Modified 3 files to read model from environment:
- `server/services/expand_chat_session.py`
- `server/services/spec_chat_session.py`
- `server/services/assistant_chat_session.py`

## Problem
The model was hardcoded to `"claude-opus-4-5-20251101"`, causing API errors when using alternative providers that don't support Claude model names.

Example error from Issue #51:
```
API Error: 400 {"error":"Your model name should start with an hf: prefix..."}
```

## Solution
```python
# Before
model="claude-opus-4-5-20251101",

# After
model = os.getenv("ANTHROPIC_DEFAULT_OPUS_MODEL", "claude-opus-4-5-20251101")
```

## Test plan
- [x] Verified fix applies to all three chat session services
- [ ] Test with alternative API provider (GLM/z.ai)
- [ ] Test default behavior (no env var set)

Fixes #51

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated chat session services to support dynamic AI model configuration through environment variables, enabling different model variants to be used without code changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->