### PR TITLE
fix: Windows Mimetype errors in server module (Issue#49)

### DIFF
--- a/server/routers/settings.py
+++ b/server/routers/settings.py
@@ -14,6 +14,10 @@ from fastapi import APIRouter
 
 from ..schemas import ModelInfo, ModelsResponse, SettingsResponse, SettingsUpdate
 
+# Mimetype fix for Windows
+import mimetypes
+mimetypes.add_type("text/javascript", ".js", True)
+
 # Add root to path for registry import
 ROOT_DIR = Path(__file__).parent.parent.parent
 if str(ROOT_DIR) not in sys.path:


### PR DESCRIPTION
Adding in fix for windows mimetype error in server [issue#49](https://github.com/leonvanzyl/autocoder/issues/49)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed JavaScript file recognition on Windows systems to ensure proper handling of `.js` files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->