### PR TITLE
fix: Pydantic datetime serialization for API endpoints

### DIFF
--- a/server/routers/agent.py
+++ b/server/routers/agent.py
@@ -93,7 +93,7 @@ async def get_agent_status(project_name: str):
     return AgentStatus(
         status=manager.status,
         pid=manager.pid,
-        started_at=manager.started_at,
+        started_at=manager.started_at.isoformat() if manager.started_at else None,
         yolo_mode=manager.yolo_mode,
         model=manager.model,
         parallel_mode=manager.parallel_mode,

--- a/server/routers/devserver.py
+++ b/server/routers/devserver.py
@@ -129,7 +129,7 @@ async def get_devserver_status(project_name: str) -> DevServerStatus:
         pid=manager.pid,
         url=manager.detected_url,
         command=manager._command,
-        started_at=manager.started_at,
+        started_at=manager.started_at.isoformat() if manager.started_at else None,
     )
 
 

--- a/server/routers/schedules.py
+++ b/server/routers/schedules.py
@@ -256,8 +256,8 @@ async def get_next_scheduled_run(project_name: str):
 
         return NextRunResponse(
             has_schedules=True,
-            next_start=next_start if active_count == 0 else None,
-            next_end=latest_end,
+            next_start=next_start.isoformat() if (active_count == 0 and next_start) else None,
+            next_end=latest_end.isoformat() if latest_end else None,
             is_currently_running=active_count > 0,
             active_schedule_count=active_count,
         )


### PR DESCRIPTION
## Problem

Several API endpoints return 500 Internal Server Error when datetime objects are present:

- `GET /agent/{project}/status`
- `GET /devserver/{project}/status`
- `GET /schedules/{project}/next`

**Error message:**
```
TypeError: Object of type datetime is not JSON serializable
```

## Root Cause

Pydantic response models expect strings for `Optional[str]` datetime fields, but the code was passing raw `datetime` objects from the manager classes.

## Solution

Convert datetime objects to ISO 8601 strings using `.isoformat()` before returning in Pydantic response models:

```python
# Before
started_at=manager.started_at,

# After
started_at=manager.started_at.isoformat() if manager.started_at else None,
```

## Files Changed

- `server/routers/agent.py` - Fix `started_at` serialization
- `server/routers/devserver.py` - Fix `started_at` serialization
- `server/routers/schedules.py` - Fix `next_start`/`next_end` serialization

## Testing

After this fix, all three endpoints return 200 OK with properly formatted datetime strings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Standardized timestamp formatting across API responses for improved compatibility. Agent status, dev server status, and schedule endpoints now consistently return all timestamp fields (started_at, next_start, next_end) as ISO 8601-formatted strings instead of raw objects. This ensures better interoperability with client applications and standard tools that expect standardized date formats.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->