### PR TITLE
fix: stop spawning testing agents after project completion

### DIFF
--- a/parallel_orchestrator.py
+++ b/parallel_orchestrator.py
@@ -401,6 +401,10 @@ class ParallelOrchestrator:
         if passing_count == 0:
             return
 
+        # Don't spawn testing agents if all features are already complete
+        if self.get_all_complete():
+            return
+
         # Spawn testing agents one at a time, re-checking limits each time
         # This avoids TOCTOU race by holding lock during the decision
         while True:


### PR DESCRIPTION
## Summary
- Added completion check to prevent testing agents from spawning after all features pass
- Stops unnecessary token consumption after project reaches 100%

## Problem
When all features pass, the orchestrator continued spawning testing agents for 10+ minutes, wasting tokens on regression tests that weren't needed.

## Root Cause
`_maintain_testing_agents()` at line 380 had no check for project completion. It only checked:
- `if self.yolo_mode or self.testing_agent_ratio == 0: return`
- `if passing_count == 0: return`

When all features pass, `passing_count > 0`, so it kept spawning testing agents even after `get_all_complete()` returns True.

## Fix
Added completion check after line 401:
```python
# Don't spawn testing agents if all features are already complete
if self.get_all_complete():
    return
```

## Testing
1. Create project with 3 features
2. Run agent until 100% complete
3. Verify: Agent stops within 30 seconds of completion
4. Check logs: No "Spawning testing agent" after "All features complete"

Fixes #66

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized testing agent spawning to skip unnecessary initialization when all features are complete, improving resource efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->