### PR TITLE
feat: add --host argument for WebUI remote access

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -88,35 +88,49 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
-# CORS - allow only localhost origins for security
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=[
-        "http://localhost:5173",      # Vite dev server
-        "http://127.0.0.1:5173",
-        "http://localhost:8888",      # Production
-        "http://127.0.0.1:8888",
-    ],
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
+# Check if remote access is enabled via environment variable
+# Set by start_ui.py when --host is not 127.0.0.1
+ALLOW_REMOTE = os.environ.get("AUTOCODER_ALLOW_REMOTE", "").lower() in ("1", "true", "yes")
+
+# CORS - allow all origins when remote access is enabled, otherwise localhost only
+if ALLOW_REMOTE:
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],  # Allow all origins for remote access
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+else:
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=[
+            "http://localhost:5173",      # Vite dev server
+            "http://127.0.0.1:5173",
+            "http://localhost:8888",      # Production
+            "http://127.0.0.1:8888",
+        ],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
 
 
 # ============================================================================
 # Security Middleware
 # ============================================================================
 
-@app.middleware("http")
-async def require_localhost(request: Request, call_next):
-    """Only allow requests from localhost."""
-    client_host = request.client.host if request.client else None
+if not ALLOW_REMOTE:
+    @app.middleware("http")
+    async def require_localhost(request: Request, call_next):
+        """Only allow requests from localhost (disabled when AUTOCODER_ALLOW_REMOTE=1)."""
+        client_host = request.client.host if request.client else None
 
-    # Allow localhost connections
-    if client_host not in ("127.0.0.1", "::1", "localhost", None):
-        raise HTTPException(status_code=403, detail="Localhost access only")
+        # Allow localhost connections
+        if client_host not in ("127.0.0.1", "::1", "localhost", None):
+            raise HTTPException(status_code=403, detail="Localhost access only")
 
-    return await call_next(request)
+        return await call_next(request)
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary
- Added `--host` and `--port` CLI arguments to `start_ui.py`
- Enables remote access to WebUI (e.g., via VS Code tunnels, remote servers)
- Includes security warning when remote access is enabled

## Problem
Users couldn't access WebUI remotely. The server was hardcoded to `127.0.0.1`, blocking VS Code tunnel users and remote server deployments.

## Solution
```bash
# Current (localhost only)
python start_ui.py

# After fix (remote access)
python start_ui.py --host 0.0.0.0
python start_ui.py --host 0.0.0.0 --port 8888
```

## Implementation

### start_ui.py
- Added argparse with `--host` (default: 127.0.0.1) and `--port` arguments
- Security warning displayed when `--host` is not localhost
- Sets `AUTOCODER_ALLOW_REMOTE=1` environment variable for server
- Browser auto-open disabled for remote hosts

### server/main.py
- Checks `AUTOCODER_ALLOW_REMOTE` environment variable
- When enabled:
  - CORS allows all origins (`*`)
  - Localhost-only middleware is disabled
- When disabled (default):
  - CORS restricted to localhost origins
  - Localhost-only middleware enforced

## Security Warning
When remote access is enabled, users see:
```
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
  SECURITY WARNING
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
  Remote access enabled on host: 0.0.0.0
  The AutoCoder UI will be accessible from other machines.
  Ensure you understand the security implications:
  - The agent has file system access to project directories
  - The API can start/stop agents and modify files
  - Consider using a firewall or VPN for protection
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
```

## Testing
```bash
python start_ui.py --host 0.0.0.0 --port 8888

# Verify:
# 1. Should print security warning
# 2. Access from remote machine: http://server-ip:8888
# 3. Should work without CORS errors
```

Fixes #81

🤖 Generated with [Claude Code](https://claude.ai/code)