### PR TITLE
fix: handle 404 errors for deleted assistant conversations

### DIFF
--- a/ui/src/components/AssistantPanel.tsx
+++ b/ui/src/components/AssistantPanel.tsx
@@ -57,8 +57,12 @@ export function AssistantPanel({ projectName, isOpen, onClose }: AssistantPanelP
   // Clear stored conversation ID if it no longer exists (404 error)
   useEffect(() => {
     if (conversationError && conversationId) {
-      console.warn(`Conversation ${conversationId} not found, clearing stored ID`)
-      setConversationId(null)
+      const message = conversationError.message.toLowerCase()
+      // Only clear for 404 errors, not transient network issues
+      if (message.includes('not found') || message.includes('404')) {
+        console.warn(`Conversation ${conversationId} not found, clearing stored ID`)
+        setConversationId(null)
+      }
     }
   }, [conversationError, conversationId])
 

--- a/ui/src/hooks/useConversations.ts
+++ b/ui/src/hooks/useConversations.ts
@@ -27,8 +27,11 @@ export function useConversation(projectName: string | null, conversationId: numb
     enabled: !!projectName && !!conversationId,
     staleTime: 30_000, // Cache for 30 seconds
     retry: (failureCount, error) => {
-      // Don't retry on 404 errors (conversation doesn't exist)
-      if (error instanceof Error && error.message.includes('404')) {
+      // Don't retry on "not found" errors (404) - conversation doesn't exist
+      if (error instanceof Error && (
+        error.message.toLowerCase().includes('not found') ||
+        error.message === 'HTTP 404'
+      )) {
         return false
       }
       return failureCount < 3


### PR DESCRIPTION
## Summary
- Fix endless 404 errors when stored conversation ID no longer exists
- Stop retrying on 404 errors (conversation doesn't exist)
- Automatically clear invalid conversation ID from localStorage

## Test plan
- [ ] Delete assistant.db or reset database while having active conversation
- [ ] Refresh browser - should see warning in console and no repeated 404 errors
- [ ] Assistant should work normally with new conversation

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when a conversation is no longer available to avoid stale state and errors.
  * Added automatic retry for transient conversation-loading failures to improve reliability (fewer interruptions).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->