### PR TITLE
feat: add EXTRA_READ_PATHS for read-only external file access

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,13 @@
 # - false: Browser opens a visible window (useful for debugging)
 # PLAYWRIGHT_HEADLESS=true
 
+# Extra Read Paths (Optional)
+# Comma-separated list of absolute paths for read-only access to external directories.
+# The agent can read files from these paths but cannot write to them.
+# Useful for referencing documentation, shared libraries, or other projects.
+# Example: EXTRA_READ_PATHS=/Volumes/Data/dev,/Users/shared/libs
+# EXTRA_READ_PATHS=
+
 # GLM/Alternative API Configuration (Optional)
 # To use Zhipu AI's GLM models instead of Claude, uncomment and set these variables.
 # This only affects AutoCoder - your global Claude Code settings remain unchanged.


### PR DESCRIPTION
# PR: Add External Read Paths Support

## Summary

Allow agents to read files from external directories outside the project folder via the `EXTRA_READ_PATHS` environment variable. This enables referencing documentation, shared libraries, or other projects without compromising write security.

## Changes

### Files Modified

| File | Changes |
|------|---------|
| `client.py` | Added `EXTRA_READ_PATHS` support (3 locations) |
| `.env.example` | Added documentation for the new environment variable |

### Code Changes

#### 1. client.py - Constant Definition (line 45-48)

```python
# Extra read paths for cross-project file access (read-only)
# Set EXTRA_READ_PATHS environment variable with comma-separated absolute paths
# Example: EXTRA_READ_PATHS=/Volumes/Data/dev,/Users/shared/libs
EXTRA_READ_PATHS_VAR = "EXTRA_READ_PATHS"
```

#### 2. client.py - Permission Logic (line 206-215)

```python
# Add extra read paths from environment variable (read-only access)
extra_read_paths = os.getenv(EXTRA_READ_PATHS_VAR, "")
if extra_read_paths:
    for path in extra_read_paths.split(","):
        path = path.strip()
        if path:
            # Add read-only permissions for each extra path
            permissions_list.append(f"Read({path}/**)")
            permissions_list.append(f"Glob({path}/**)")
            permissions_list.append(f"Grep({path}/**)")
```

#### 3. client.py - Logging (line 231-232)

```python
if extra_read_paths:
    print(f"   - Extra read paths: {extra_read_paths}")
```

#### 4. .env.example - Documentation

```bash
# Extra Read Paths (Optional)
# Comma-separated list of absolute paths for read-only access to external directories.
# The agent can read files from these paths but cannot write to them.
# Useful for referencing documentation, shared libraries, or other projects.
# Example: EXTRA_READ_PATHS=/Volumes/Data/dev,/Users/shared/libs
# EXTRA_READ_PATHS=
```

## Usage

### Configuration

Add to `.env` file:

```bash
# Single path
EXTRA_READ_PATHS=/Users/me/docs

# Multiple paths (comma-separated)
EXTRA_READ_PATHS=/Users/me/docs,/opt/shared-libs,/Volumes/Data/reference
```

### Agent Capabilities

When `EXTRA_READ_PATHS` is set, the agent can:

| Operation | Project Directory | Extra Read Paths | Other Locations |
|-----------|-------------------|------------------|-----------------|
| **Read** | Yes | Yes | No |
| **Glob** | Yes | Yes | No |
| **Grep** | Yes | Yes | No |
| **Write** | Yes | No | No |
| **Edit** | Yes | No | No |

### Example Output

When the agent starts with extra read paths configured:

```
Created security settings at /path/to/project/.claude_settings.json
   - Sandbox enabled (OS-level bash isolation)
   - Filesystem restricted to: /path/to/project
   - Extra read paths: /Users/me/docs,/opt/shared-libs
   - Bash commands restricted to allowlist (see security.py)
   - MCP servers: playwright (browser), features (database)
```

## Use Cases

1. **Reference Documentation**: Read internal docs or style guides from a shared location
2. **Cross-Project Reference**: Look at implementation patterns from other projects
3. **Shared Libraries**: Access common utilities or templates without copying them
4. **Team Resources**: Reference team-wide configuration or examples

## Security Considerations

- **Read-Only Access**: External paths only allow `Read`, `Glob`, and `Grep` operations
- **No Write Access**: Agents cannot modify files outside the project directory
- **Explicit Configuration**: Paths must be explicitly set in `.env`
- **Existing Security Maintained**: Bash command allowlist, sandbox, and project-level restrictions remain unchanged

## Testing

### Manual Testing

1. Set `EXTRA_READ_PATHS` in `.env`:
   ```bash
   EXTRA_READ_PATHS=/tmp/test-read-paths
   ```

2. Create test directory and file:
   ```bash
   mkdir -p /tmp/test-read-paths
   echo "test content" > /tmp/test-read-paths/test.txt
   ```

3. Start the agent and verify:
   - Log shows "Extra read paths: /tmp/test-read-paths"
   - Agent can read `/tmp/test-read-paths/test.txt`
   - Agent cannot write to `/tmp/test-read-paths/`

### Verification Checklist

- Agent logs show extra read paths when configured
- Agent can read files from extra paths
- Agent can use Glob on extra paths
- Agent can use Grep on extra paths
- Agent cannot write to extra paths
- Agent cannot edit files in extra paths
- No extra paths are added when env var is empty/unset


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now configure additional read paths through environment variables, enabling flexible file system permission management without code changes. Multiple paths can be specified as a comma-separated list for convenient management.
  * Enhanced environment configuration documentation with comprehensive setup examples and detailed parameter descriptions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->