### PR TITLE
fix: add UTF-8 encoding for subprocess calls on Windows

### DIFF
--- a/start.py
+++ b/start.py
@@ -231,7 +231,9 @@ def run_spec_creation(project_dir: Path) -> bool:
             check=False,  # Don't raise on non-zero exit
             cwd=str(Path(__file__).parent),  # Run from project root
             stderr=subprocess.PIPE,
-            text=True
+            text=True,
+            encoding="utf-8",  # Fix Windows CP1252 encoding issue (#138)
+            errors="replace",
         )
 
         # Check for authentication errors in stderr
@@ -403,7 +405,9 @@ def run_agent(project_name: str, project_dir: Path) -> None:
             cmd,
             check=False,
             stderr=subprocess.PIPE,
-            text=True
+            text=True,
+            encoding="utf-8",  # Fix Windows CP1252 encoding issue (#138)
+            errors="replace",
         )
 
         # Check for authentication errors

--- a/start_ui.py
+++ b/start_ui.py
@@ -127,7 +127,9 @@ def check_node() -> bool:
         result = subprocess.run(
             ["node", "--version"],
             capture_output=True,
-            text=True
+            text=True,
+            encoding="utf-8",  # Fix Windows CP1252 encoding issue (#138)
+            errors="replace",
         )
         print(f"  Node.js version: {result.stdout.strip()}")
     except Exception:


### PR DESCRIPTION
## Summary
- Fix Windows UTF-8 encoding issue in subprocess calls
- Add `encoding="utf-8"` and `errors="replace"` to all subprocess calls that use `text=True`

## Problem
Windows users experience `UnicodeDecodeError` when running parallel mode because `subprocess.Popen` with `text=True` defaults to CP1252 encoding instead of UTF-8.

## Solution
Explicitly specify UTF-8 encoding for all subprocess calls that process text output from Claude agents.

## Files Modified
- `parallel_orchestrator.py` (3 locations)
- `start.py` (2 locations)
- `start_ui.py` (1 location)

## Testing
- Verified ruff linting passes: `ruff check parallel_orchestrator.py start.py start_ui.py`
- The fix is low-risk and only explicitly specifies UTF-8 encoding which is already the expected behavior on non-Windows systems

## Notes
- Files `quality_gates.py`, `git_workflow.py`, `review_agent.py`, and `security_scanner.py` mentioned in issue #138 don't exist on master - they are only in feature branches. This PR fixes all affected files on master.
- PR #117 (mega merge) may have merge conflicts with this change

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced text encoding handling across system operations to improve Windows platform compatibility and prevent character encoding failures.
  * Improved error resilience during system initialization and background operations to ensure reliable text output processing.
  * Strengthened encoding error handling throughout critical system processes for more robust and stable operation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->