### PR TITLE
Fix: auto-start agent after spec creation from empty Kanban

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -28,7 +28,7 @@ import { KeyboardShortcutsHelp } from './components/KeyboardShortcutsHelp'
 import { ThemeSelector } from './components/ThemeSelector'
 import { ResetProjectModal } from './components/ResetProjectModal'
 import { ProjectSetupRequired } from './components/ProjectSetupRequired'
-import { getDependencyGraph } from './lib/api'
+import { getDependencyGraph, startAgent } from './lib/api'
 import { Loader2, Settings, Moon, Sun, RotateCcw } from 'lucide-react'
 import type { Feature } from './lib/types'
 import { Button } from '@/components/ui/button'
@@ -495,7 +495,16 @@ function App() {
         <div className="fixed inset-0 z-50 bg-background">
           <SpecCreationChat
             projectName={selectedProject}
-            onComplete={() => {
+            onComplete={async (_specPath, yoloMode) => {
+              // Auto-start the agent after spec creation (same as NewProjectModal)
+              try {
+                await startAgent(selectedProject, {
+                  yoloMode: yoloMode ?? false,
+                  maxConcurrency: 3,
+                })
+              } catch (err) {
+                console.error('Failed to start agent:', err)
+              }
               setShowSpecChat(false)
               // Refresh projects to update has_spec
               queryClient.invalidateQueries({ queryKey: ['projects'] })


### PR DESCRIPTION
## Summary

Fixes #144

When creating a spec from an empty Kanban board (via "Create Spec" button), the agent was not automatically starting after clicking "Continue to Project". Users had to manually click the Play button to start the agent.

## Root Cause

`SpecCreationChat` component is used in two places with different `onComplete` handlers:

| Location | Usage | `onComplete` behavior |
|----------|-------|----------------------|
| `NewProjectModal.tsx` | New project creation | ✅ Calls `startAgent()` |
| `App.tsx` | Create spec from empty Kanban | ❌ Did NOT call `startAgent()` |

The `App.tsx` version only closed the chat and refreshed queries but did not start the agent.

## Changes

- Add `startAgent` import to `App.tsx`
- Update `onComplete` handler to call `startAgent()` with `yoloMode` and `maxConcurrency` parameters


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent now automatically initiates after spec creation, eliminating the need for manual startup and streamlining the workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->