### PR TITLE
feat: support custom Opus model via ANTHROPIC_DEFAULT_OPUS_MODEL env var

### DIFF
--- a/registry.py
+++ b/registry.py
@@ -40,11 +40,15 @@ VALID_MODELS = [m["id"] for m in AVAILABLE_MODELS]
 
 # Default model and settings
 # Respect ANTHROPIC_DEFAULT_OPUS_MODEL env var for Foundry/custom deployments
-DEFAULT_MODEL = os.getenv("ANTHROPIC_DEFAULT_OPUS_MODEL", "claude-opus-4-5-20251101")
+# Guard against empty/whitespace values by trimming and falling back when blank
+_env_default_model = os.getenv("ANTHROPIC_DEFAULT_OPUS_MODEL")
+if _env_default_model is not None:
+    _env_default_model = _env_default_model.strip()
+DEFAULT_MODEL = _env_default_model or "claude-opus-4-5-20251101"
 
 # Ensure env-provided DEFAULT_MODEL is in VALID_MODELS for validation consistency
 # (idempotent: only adds if missing, doesn't alter AVAILABLE_MODELS semantics)
-if DEFAULT_MODEL not in VALID_MODELS:
+if DEFAULT_MODEL and DEFAULT_MODEL not in VALID_MODELS:
     VALID_MODELS.append(DEFAULT_MODEL)
 DEFAULT_YOLO_MODE = False
 


### PR DESCRIPTION
Allow custom deployments to override the default Opus model by setting the ANTHROPIC_DEFAULT_OPUS_MODEL environment variable.  Allows for flexibility when Anthropic changes names of models without redeploying the solution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Default model selection is now configurable via an environment variable, allowing deployments to override the built-in default without code changes.
  * Environment-provided model names are normalized (whitespace trimmed) and automatically accepted into the app's list of valid models to ensure they work at runtime.
  * Backward compatibility preserved when the variable is unset or blank.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->