### PR TITLE
feat: Add custom MCP server support

### DIFF
--- a/client.py
+++ b/client.py
@@ -17,7 +17,6 @@ from claude_agent_sdk import ClaudeAgentOptions, ClaudeSDKClient
 from claude_agent_sdk.types import HookContext, HookInput, HookMatcher, SyncHookJSONOutput
 from dotenv import load_dotenv
 
-from env_constants import API_ENV_VARS
 from security import (
     SENSITIVE_DIRECTORIES,
     bash_security_hook,

--- a/examples/org_config.yaml
+++ b/examples/org_config.yaml
@@ -92,6 +92,78 @@ blocked_commands: []
 
 
 # ==========================================
+# Custom MCP Servers
+# ==========================================
+# Configure additional MCP (Model Context Protocol) servers that will be
+# available to the agent in ALL projects.
+#
+# Each MCP server MUST specify:
+#   - name: Unique identifier for the server
+#   - command: Command to run (e.g., "npx", "python")
+#   - allowed_tools: REQUIRED list of tools to allow (explicit allowlist)
+#
+# Optional fields:
+#   - args: List of command arguments
+#   - env: Environment variables (merged with parent environment)
+#
+# Variable substitution is supported:
+#   - ${PROJECT_DIR} - Absolute path to current project directory
+#   - ${HOME} - User's home directory
+#
+# By default, no custom MCP servers are configured.
+
+mcp_servers: []
+
+  # Example: Filesystem MCP server (read-only)
+  # - name: filesystem
+  #   command: npx
+  #   args:
+  #     - "@anthropic/mcp-server-filesystem"
+  #     - "${PROJECT_DIR}"
+  #   allowed_tools:
+  #     - read_file
+  #     - list_directory
+  #     - search_files
+
+  # Example: Memory MCP server for persistent context
+  # - name: memory
+  #   command: npx
+  #   args:
+  #     - "@anthropic/mcp-server-memory"
+  #   env:
+  #     MEMORY_DIR: "${HOME}/.autocoder/memory"
+  #   allowed_tools:
+  #     - store_memory
+  #     - retrieve_memory
+  #     - search_memory
+
+
+# ==========================================
+# Blocked MCP Tools (Organization-Wide)
+# ==========================================
+# Tools listed here are BLOCKED across ALL projects.
+# Projects CANNOT override these blocks.
+#
+# Tool naming convention: {server}__{tool} or mcp__{server}__{tool}
+# Examples:
+#   - filesystem__write_file    (blocks filesystem server's write_file tool)
+#   - filesystem__delete_file   (blocks filesystem server's delete_file tool)
+#   - myserver__*               (blocks ALL tools from myserver - wildcard)
+#
+# By default, no tools are blocked.
+
+blocked_mcp_tools: []
+
+  # Block dangerous filesystem operations
+  # - filesystem__write_file
+  # - filesystem__delete_file
+  # - filesystem__move_file
+
+  # Block all tools from a specific server (wildcard)
+  # - dangerous_server__*
+
+
+# ==========================================
 # Global Settings (Phase 3 feature)
 # ==========================================
 # These settings control approval behavior when agents request

--- a/examples/project_allowed_commands.yaml
+++ b/examples/project_allowed_commands.yaml
@@ -104,6 +104,53 @@ commands: []
 
 
 # ==========================================
+# Custom MCP Servers
+# ==========================================
+# Configure additional MCP (Model Context Protocol) servers for THIS PROJECT.
+# These are added to any org-level MCP servers defined in ~/.autocoder/config.yaml
+#
+# Each MCP server MUST specify:
+#   - name: Unique identifier for the server
+#   - command: Command to run (e.g., "npx", "python")
+#   - allowed_tools: REQUIRED list of tools to allow (explicit allowlist)
+#
+# Optional fields:
+#   - args: List of command arguments
+#   - env: Environment variables (merged with parent environment)
+#
+# Variable substitution is supported:
+#   - ${PROJECT_DIR} - Absolute path to current project directory
+#   - ${HOME} - User's home directory
+#
+# By default, no custom MCP servers are configured.
+
+mcp_servers: []
+
+  # Example: SQLite MCP server for this project's database
+  # - name: sqlite
+  #   command: npx
+  #   args:
+  #     - "@anthropic/mcp-server-sqlite"
+  #     - "${PROJECT_DIR}/data.db"
+  #   allowed_tools:
+  #     - read_query
+  #     - list_tables
+  #     - describe_table
+
+  # Example: Custom project-specific MCP server
+  # - name: my_project_tools
+  #   command: python
+  #   args:
+  #     - "${PROJECT_DIR}/tools/mcp_server.py"
+  #   env:
+  #     PROJECT_ROOT: "${PROJECT_DIR}"
+  #   allowed_tools:
+  #     - build_project
+  #     - run_tests
+  #     - deploy_staging
+
+
+# ==========================================
 # Notes and Best Practices
 # ==========================================
 #

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -96,6 +96,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -2825,6 +2826,7 @@
       "integrity": "sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2834,6 +2836,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.9.tgz",
       "integrity": "sha512-Lpo8kgb/igvMIPeNV2rsYKTgaORYdO1XGVZ4Qz3akwOj0ySGYMPlQWa8BaLn0G63D1aSaAQ5ldR06wCpChQCjA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2844,6 +2847,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2899,6 +2903,7 @@
       "integrity": "sha512-3xP4XzzDNQOIqBMWogftkwxhg5oMKApqY0BAflmLZiFYHqyhSOxv/cd/zPQLTcCXr4AkaKb25joocY0BD1WC6A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.51.0",
         "@typescript-eslint/types": "8.51.0",
@@ -3209,6 +3214,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3340,6 +3346,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3611,6 +3618,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -3836,6 +3844,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5836,6 +5845,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5951,6 +5961,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5960,6 +5971,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6424,6 +6436,7 @@
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6677,6 +6690,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",


### PR DESCRIPTION
Introduces the ability to configure additional MCP (Model Context Protocol) servers through organization and project configuration files. This feature extends the agent's capabilities by allowing users to define custom tools.

Implements a robust configuration system that:
- Loads and validates MCP server definitions and org-level blocked tools.
- Supports variable substitution in commands, arguments, and environment variables.
- Resolves configuration hierarchy, allowing project-level definitions to override organization-level ones.
- Integrates custom tools into the agent's security context, enforcing explicit tool allowlists and organization-wide blocks.

Updates `CLAUDE.md` with detailed documentation on configuring and managing custom MCP servers, including schema and key behaviors. Provides example configuration files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Custom MCP server configuration at org and project levels with runtime loading and inclusion
  * Tool allow/block controls for MCP servers with effective permission resolution
  * Variable substitution (e.g., ${PROJECT_DIR}, ${HOME}) in server configs
  * Runtime reporting of configured and blocked MCP servers/tools

* **Documentation**
  * Expanded MCP docs with schema, examples, behavior notes, and sample configs

* **Tests**
  * Added tests for MCP validation, loading, hierarchy resolution, and pattern matching

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->