### PR TITLE
fix: improve start_ui.sh compatibility for Linux environments

### DIFF
--- a/start_ui.sh
+++ b/start_ui.sh
@@ -1,5 +1,10 @@
-#!/bin/bash
-cd "$(dirname "$0")"
+#!/usr/bin/env bash
+set -e  # Exit on error
+
+# Change to script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
 # AutoForge UI Launcher for Unix/Linux/macOS
 # This script launches the web UI for the autonomous coding agent.
 
@@ -30,17 +35,34 @@ else
 fi
 echo ""
 
-# Check if Python is available
-if ! command -v python3 &> /dev/null; then
-    if ! command -v python &> /dev/null; then
-        echo "ERROR: Python not found"
-        echo "Please install Python from https://python.org"
-        exit 1
+# Check if Python is available and meet version requirements
+PYTHON_CMD=""
+for cmd in python3.13 python3.12 python3.11 python3 python; do
+    if command -v "$cmd" &> /dev/null; then
+        PYTHON_CMD="$cmd"
+        break
     fi
-    PYTHON_CMD="python"
-else
-    PYTHON_CMD="python3"
+done
+
+if [ -z "$PYTHON_CMD" ]; then
+    echo "ERROR: Python not found"
+    echo "Please install Python 3.11+ from https://python.org"
+    exit 1
 fi
+
+# Verify Python version is 3.11+
+PYTHON_VERSION=$($PYTHON_CMD -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
+PYTHON_MAJOR=$(echo "$PYTHON_VERSION" | cut -d. -f1)
+PYTHON_MINOR=$(echo "$PYTHON_VERSION" | cut -d. -f2)
+
+if [ "$PYTHON_MAJOR" -lt 3 ] || ([ "$PYTHON_MAJOR" -eq 3 ] && [ "$PYTHON_MINOR" -lt 11 ]); then
+    echo "ERROR: Python 3.11+ required (found $PYTHON_VERSION)"
+    echo "Please upgrade Python or install a newer version"
+    exit 1
+fi
+
+echo "[OK] Using Python $PYTHON_VERSION ($PYTHON_CMD)"
+echo ""
 
 # Check if venv exists with correct structure for this platform
 # Windows venvs have Scripts/, Linux/macOS have bin/
@@ -55,30 +77,69 @@ if [ ! -f "venv/bin/activate" ]; then
             echo "  rm -rf venv"
             exit 1
         fi
-    else
-        echo "Creating virtual environment..."
     fi
-    $PYTHON_CMD -m venv venv
-    if [ $? -ne 0 ]; then
+    echo "Creating virtual environment..."
+    if ! $PYTHON_CMD -m venv venv; then
         echo "[ERROR] Failed to create virtual environment"
         echo "Please ensure the venv module is installed:"
         echo "  Ubuntu/Debian: sudo apt install python3-venv"
+        echo "  Fedora/RHEL: sudo dnf install python3-venv"
         echo "  Or try: $PYTHON_CMD -m ensurepip"
         exit 1
     fi
+    echo "[OK] Virtual environment created"
 fi
 
+# Detect package manager preference (uv > pip3 > pip)
+PKG_MGR=""
+if command -v uv &> /dev/null; then
+    PKG_MGR="uv"
+    echo "[OK] Using uv package manager"
+elif command -v pip3 &> /dev/null; then
+    PKG_MGR="pip3"
+    echo "[OK] Using pip3 package manager"
+elif command -v pip &> /dev/null; then
+    PKG_MGR="pip"
+    echo "[OK] Using pip package manager"
+else
+    echo "[ERROR] No package manager found (pip, pip3, or uv required)"
+    exit 1
+fi
+echo ""
+
 # Activate the virtual environment
-source venv/bin/activate
-if [ $? -ne 0 ]; then
-    echo "[ERROR] Failed to activate virtual environment"
+if [ -f "venv/bin/activate" ]; then
+    # shellcheck disable=SC1091
+    source venv/bin/activate
+else
+    echo "[ERROR] Virtual environment activation script not found"
     echo "The venv may be corrupted. Try: rm -rf venv && ./start_ui.sh"
     exit 1
 fi
 
-# Install dependencies
+# Install dependencies based on package manager
 echo "Installing dependencies..."
-pip install -r requirements.txt --quiet
+if [ "$PKG_MGR" = "uv" ]; then
+    if ! uv pip install -r requirements.txt --quiet; then
+        echo "[ERROR] Failed to install dependencies with uv"
+        echo "Try manually: uv pip install -r requirements.txt"
+        exit 1
+    fi
+else
+    # Upgrade pip to avoid warnings (only for pip/pip3)
+    echo "Ensuring pip is up to date..."
+    $PKG_MGR install --upgrade pip --quiet 2>&1 | grep -v "Requirement already satisfied" || true
+
+    if ! $PKG_MGR install -r requirements.txt --quiet; then
+        echo "[ERROR] Failed to install dependencies"
+        echo "Try manually: source venv/bin/activate && $PKG_MGR install -r requirements.txt"
+        exit 1
+    fi
+fi
+
+echo ""
+echo "Starting AutoForge UI server..."
+echo ""
 
 # Ensure playwright-cli is available for browser automation
 if ! command -v playwright-cli &> /dev/null; then
@@ -90,4 +151,4 @@ if ! command -v playwright-cli &> /dev/null; then
 fi
 
 # Run the Python launcher
-python start_ui.py "$@"
+exec $PYTHON_CMD start_ui.py "$@"


### PR DESCRIPTION
Fixes #168

## Summary
This PR addresses several compatibility issues in `start_ui.sh` that prevented it from working correctly in certain Linux environments.

## Changes
- ✅ Auto-detect package manager with preference order: `uv` > `pip3` > `pip`
- ✅ Use detected `$PYTHON_CMD` variable consistently throughout script
- ✅ Check for Python 3.11+ requirement before proceeding
- ✅ Try multiple Python commands in order: `python3.13`, `python3.12`, `python3.11`, `python3`, `python`
- ✅ Use portable shebang: `#!/usr/bin/env bash`
- ✅ Add `set -e` for better error handling
- ✅ Improve error messages and diagnostics
- ✅ Use `exec` for final Python invocation

## Testing
- [x] Tested on Linux with `uv` and `python3`
- [x] Verified script works with systems that only have `pip3` or `uv` available
- [x] Confirmed proper Python version detection

## Files Changed
- `start_ui.sh`