### PR TITLE
feat: smart testing mode — skip Playwright for API/backend features

### DIFF
--- a/autonomous_agent_demo.py
+++ b/autonomous_agent_demo.py
@@ -186,6 +186,14 @@ Authentication:
         help="Max features per coding agent batch (1-3, default: 3)",
     )
 
+    parser.add_argument(
+        "--testing-mode",
+        type=str,
+        default="full",
+        choices=["full", "smart"],
+        help="Testing mode: full (always Playwright), smart (Playwright for UI only)",
+    )
+
     return parser.parse_args()
 
 
@@ -269,6 +277,7 @@ def main() -> None:
                     agent_type=args.agent_type,
                     testing_feature_id=args.testing_feature_id,
                     testing_feature_ids=testing_feature_ids,
+                    testing_mode=args.testing_mode,
                 )
             )
         else:
@@ -300,6 +309,7 @@ def main() -> None:
                     testing_agent_ratio=args.testing_ratio,
                     testing_batch_size=args.testing_batch_size,
                     batch_size=args.batch_size,
+                    testing_mode=args.testing_mode,
                 )
             )
     except KeyboardInterrupt:

--- a/parallel_orchestrator.py
+++ b/parallel_orchestrator.py
@@ -155,6 +155,7 @@ class ParallelOrchestrator:
         testing_agent_ratio: int = 1,
         testing_batch_size: int = DEFAULT_TESTING_BATCH_SIZE,
         batch_size: int = 3,
+        testing_mode: str = "full",
         on_output: Callable[[int, str], None] | None = None,
         on_status: Callable[[int, str], None] | None = None,
     ):
@@ -170,6 +171,7 @@ class ParallelOrchestrator:
                 0 = disabled, 1-3 = maintain that many testing agents running independently.
             testing_batch_size: Number of features to include per testing session (1-5).
                 Each testing agent receives this many features to regression test.
+            testing_mode: Testing mode - full (always Playwright) or smart (UI only)
             on_output: Callback for agent output (feature_id, line)
             on_status: Callback for agent status changes (feature_id, status)
         """
@@ -178,6 +180,7 @@ class ParallelOrchestrator:
         self.model = model
         self.yolo_mode = yolo_mode
         self.testing_agent_ratio = min(max(testing_agent_ratio, 0), 3)  # Clamp 0-3
+        self.testing_mode = testing_mode
         self.testing_batch_size = min(max(testing_batch_size, 1), 5)  # Clamp 1-5
         self.batch_size = min(max(batch_size, 1), 3)  # Clamp 1-3
         self.on_output = on_output
@@ -828,6 +831,7 @@ class ParallelOrchestrator:
             "--max-iterations", "1",
             "--agent-type", "coding",
             "--feature-id", str(feature_id),
+            "--testing-mode", self.testing_mode,
         ]
         if self.model:
             cmd.extend(["--model", self.model])
@@ -1651,6 +1655,7 @@ async def run_parallel_orchestrator(
     testing_agent_ratio: int = 1,
     testing_batch_size: int = DEFAULT_TESTING_BATCH_SIZE,
     batch_size: int = 3,
+    testing_mode: str = "full",
 ) -> None:
     """Run the unified orchestrator.
 
@@ -1662,8 +1667,9 @@ async def run_parallel_orchestrator(
         testing_agent_ratio: Number of regression agents to maintain (0-3)
         testing_batch_size: Number of features per testing batch (1-5)
         batch_size: Max features per coding agent batch (1-3)
+        testing_mode: Testing mode - full or smart
     """
-    print(f"[ORCHESTRATOR] run_parallel_orchestrator called with max_concurrency={max_concurrency}", flush=True)
+    print(f"[ORCHESTRATOR] run_parallel_orchestrator called with max_concurrency={max_concurrency}, testing_mode={testing_mode}", flush=True)
     orchestrator = ParallelOrchestrator(
         project_dir=project_dir,
         max_concurrency=max_concurrency,
@@ -1672,6 +1678,7 @@ async def run_parallel_orchestrator(
         testing_agent_ratio=testing_agent_ratio,
         testing_batch_size=testing_batch_size,
         batch_size=batch_size,
+        testing_mode=testing_mode,
     )
 
     # Set up cleanup to run on exit (handles normal exit, exceptions)
@@ -1763,6 +1770,13 @@ def main():
         default=3,
         help="Max features per coding agent batch (1-5, default: 3)",
     )
+    parser.add_argument(
+        "--testing-mode",
+        type=str,
+        default="full",
+        choices=["full", "smart"],
+        help="Testing mode: full (always Playwright), smart (Playwright for UI only)",
+    )
 
     args = parser.parse_args()
 
@@ -1791,6 +1805,7 @@ def main():
             testing_agent_ratio=args.testing_agent_ratio,
             testing_batch_size=args.testing_batch_size,
             batch_size=args.batch_size,
+            testing_mode=args.testing_mode,
         ))
     except KeyboardInterrupt:
         print("\n\nInterrupted by user", flush=True)

--- a/server/routers/settings.py
+++ b/server/routers/settings.py
@@ -111,6 +111,7 @@ async def get_settings():
         glm_mode=glm_mode,
         ollama_mode=ollama_mode,
         testing_agent_ratio=_parse_int(all_settings.get("testing_agent_ratio"), 1),
+        testing_mode=all_settings.get("testing_mode", "full"),
         playwright_headless=_parse_bool(all_settings.get("playwright_headless"), default=True),
         batch_size=_parse_int(all_settings.get("batch_size"), 3),
         api_provider=api_provider,
@@ -137,6 +138,9 @@ async def update_settings(update: SettingsUpdate):
 
     if update.batch_size is not None:
         set_setting("batch_size", str(update.batch_size))
+
+    if update.testing_mode is not None:
+        set_setting("testing_mode", update.testing_mode)
 
     # API provider settings
     if update.api_provider is not None:
@@ -175,6 +179,7 @@ async def update_settings(update: SettingsUpdate):
         glm_mode=glm_mode,
         ollama_mode=ollama_mode,
         testing_agent_ratio=_parse_int(all_settings.get("testing_agent_ratio"), 1),
+        testing_mode=all_settings.get("testing_mode", "full"),
         playwright_headless=_parse_bool(all_settings.get("playwright_headless"), default=True),
         batch_size=_parse_int(all_settings.get("batch_size"), 3),
         api_provider=api_provider,

--- a/server/services/process_manager.py
+++ b/server/services/process_manager.py
@@ -85,6 +85,7 @@ class AgentProcessManager:
         self.parallel_mode: bool = False  # Parallel execution mode
         self.max_concurrency: int | None = None  # Max concurrent agents
         self.testing_agent_ratio: int = 1  # Regression testing agents (0-3)
+        self.testing_mode: str = "full"  # Testing mode: full, smart
 
         # Support multiple callbacks (for multiple WebSocket clients)
         self._output_callbacks: Set[Callable[[str], Awaitable[None]]] = set()
@@ -340,6 +341,7 @@ class AgentProcessManager:
         testing_agent_ratio: int = 1,
         playwright_headless: bool = True,
         batch_size: int = 3,
+        testing_mode: str = "full",
     ) -> tuple[bool, str]:
         """
         Start the agent as a subprocess.
@@ -351,6 +353,7 @@ class AgentProcessManager:
             max_concurrency: Max concurrent coding agents (1-5, default 1)
             testing_agent_ratio: Number of regression testing agents (0-3, default 1)
             playwright_headless: If True, run browser in headless mode
+            testing_mode: Testing mode (full, smart)
 
         Returns:
             Tuple of (success, message)
@@ -370,6 +373,7 @@ class AgentProcessManager:
         self.parallel_mode = True  # Always True now (unified orchestrator)
         self.max_concurrency = max_concurrency or 1
         self.testing_agent_ratio = testing_agent_ratio
+        self.testing_mode = testing_mode
 
         # Build command - unified orchestrator with --concurrency
         cmd = [
@@ -396,6 +400,9 @@ class AgentProcessManager:
 
         # Add --batch-size flag for multi-feature batching
         cmd.extend(["--batch-size", str(batch_size)])
+
+        # Add testing mode configuration
+        cmd.extend(["--testing-mode", testing_mode])
 
         try:
             # Start subprocess with piped stdout/stderr
@@ -489,6 +496,7 @@ class AgentProcessManager:
             self.parallel_mode = False  # Reset parallel mode
             self.max_concurrency = None  # Reset concurrency
             self.testing_agent_ratio = 1  # Reset testing ratio
+            self.testing_mode = "full"  # Reset testing mode
 
             return True, "Agent stopped"
         except Exception as e:
@@ -575,6 +583,7 @@ class AgentProcessManager:
             "parallel_mode": self.parallel_mode,
             "max_concurrency": self.max_concurrency,
             "testing_agent_ratio": self.testing_agent_ratio,
+            "testing_mode": self.testing_mode,
         }
 
 

--- a/ui/src/components/SettingsModal.tsx
+++ b/ui/src/components/SettingsModal.tsx
@@ -57,6 +57,12 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
     }
   }
 
+  const handleTestingModeChange = (mode: string) => {
+    if (!updateSettings.isPending) {
+      updateSettings.mutate({ testing_mode: mode })
+    }
+  }
+
   const handleBatchSizeChange = (size: number) => {
     if (!updateSettings.isPending) {
       updateSettings.mutate({ batch_size: size })
@@ -371,6 +377,35 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
                 onCheckedChange={handleYoloToggle}
                 disabled={isSaving}
               />
+            </div>
+
+            {/* Browser Testing Mode */}
+            <div className="flex items-center justify-between">
+              <div className="space-y-0.5">
+                <Label className="font-medium">Browser Testing</Label>
+                <p className="text-sm text-muted-foreground">
+                  {(settings.testing_mode || 'full') === 'smart' ? 'UI features only' : 'All features'}
+                </p>
+              </div>
+              <div className={`flex rounded-lg border overflow-hidden ${settings.yolo_mode ? 'opacity-50' : ''}`}>
+                {[
+                  { id: 'full', label: 'Full' },
+                  { id: 'smart', label: 'Smart' },
+                ].map((mode) => (
+                  <button
+                    key={mode.id}
+                    onClick={() => handleTestingModeChange(mode.id)}
+                    disabled={isSaving || settings.yolo_mode}
+                    className={`py-1.5 px-3 text-sm font-medium transition-colors ${
+                      (settings.testing_mode || 'full') === mode.id
+                        ? 'bg-primary text-primary-foreground'
+                        : 'bg-background text-foreground hover:bg-muted'
+                    } ${(isSaving || settings.yolo_mode) ? 'cursor-not-allowed' : ''}`}
+                  >
+                    {mode.label}
+                  </button>
+                ))}
+              </div>
             </div>
 
             {/* Headless Browser Toggle */}

--- a/ui/src/hooks/useProjects.ts
+++ b/ui/src/hooks/useProjects.ts
@@ -266,6 +266,7 @@ const DEFAULT_SETTINGS: Settings = {
   glm_mode: false,
   ollama_mode: false,
   testing_agent_ratio: 1,
+  testing_mode: 'full',
   playwright_headless: true,
   batch_size: 3,
   api_provider: 'claude',

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -551,6 +551,7 @@ export interface Settings {
   glm_mode: boolean
   ollama_mode: boolean
   testing_agent_ratio: number  // Regression testing agents (0-3)
+  testing_mode: string  // "full", "smart"
   playwright_headless: boolean
   batch_size: number  // Features per coding agent batch (1-3)
   api_provider: string
@@ -563,6 +564,7 @@ export interface SettingsUpdate {
   yolo_mode?: boolean
   model?: string
   testing_agent_ratio?: number
+  testing_mode?: string
   playwright_headless?: boolean
   batch_size?: number
   api_provider?: string


### PR DESCRIPTION
## What this does

Adds a "Browser Testing" setting with two modes:

- **Full** (default): Playwright runs for every feature, same as today
- **Smart**: Playwright is only loaded for UI features. API/backend/database features skip it entirely.

This saves ~100-300MB of memory per agent when testing features that don't need a browser, which adds up quickly in parallel mode.

## How it works

A new `should_use_playwright()` function in `client.py` checks the feature's category against a list of backend keywords (`api`, `backend`, `database`, `db`, `server`, `endpoint`, `service`). If the category matches, Playwright MCP server and tools are excluded from that agent session.

The setting flows through the full stack:
- Settings UI → REST API → process manager → agent subprocess → client configuration

## Changes

**Backend (8 files):**
- `client.py` — `should_use_playwright()` function, conditional Playwright inclusion
- `agent.py` — Feature category lookup from DB when in smart mode
- `autonomous_agent_demo.py` — `--testing-mode` CLI flag
- `parallel_orchestrator.py` — Pass testing_mode to subprocess commands
- `server/routers/agent.py` — Read testing_mode from settings, pass to manager
- `server/routers/settings.py` — Persist testing_mode setting
- `server/schemas.py` — Validation, request/response schemas
- `server/services/process_manager.py` — Store and forward testing_mode

**Frontend (3 files):**
- `SettingsModal.tsx` — Full/Smart toggle buttons (disabled when YOLO is on)
- `useProjects.ts` — Default setting
- `types.ts` — TypeScript types

## Test plan

- [ ] Toggle between Full and Smart in Settings, start an agent, verify the correct mode is logged
- [ ] In Smart mode: API feature should log "NO Playwright (testing_mode=smart, category=api)"
- [ ] In Smart mode: UI feature should still get Playwright
- [ ] YOLO mode should override Smart mode (no Playwright regardless)
- [ ] Parallel mode should pass testing_mode to each subprocess