### PR TITLE
feat: add agent session logging to SQLite

### DIFF
--- a/autoforge_paths.py
+++ b/autoforge_paths.py
@@ -37,6 +37,9 @@ features.db-shm
 assistant.db
 assistant.db-wal
 assistant.db-shm
+agent_sessions.db
+agent_sessions.db-wal
+agent_sessions.db-shm
 .agent.lock
 .devserver.lock
 .claude_settings.json
@@ -123,6 +126,11 @@ def get_features_db_path(project_dir: Path) -> Path:
 def get_assistant_db_path(project_dir: Path) -> Path:
     """Resolve the path to ``assistant.db``."""
     return _resolve_path(project_dir, "assistant.db")
+
+
+def get_agent_sessions_db_path(project_dir: Path) -> Path:
+    """Resolve the path to ``agent_sessions.db``."""
+    return _resolve_path(project_dir, "agent_sessions.db")
 
 
 def get_agent_lock_path(project_dir: Path) -> Path:

--- a/server/main.py
+++ b/server/main.py
@@ -30,6 +30,7 @@ from fastapi.staticfiles import StaticFiles
 
 from .routers import (
     agent_router,
+    agent_sessions_router,
     assistant_chat_router,
     devserver_router,
     expand_project_router,
@@ -150,6 +151,7 @@ if not ALLOW_REMOTE:
 app.include_router(projects_router)
 app.include_router(features_router)
 app.include_router(agent_router)
+app.include_router(agent_sessions_router)
 app.include_router(schedules_router)
 app.include_router(devserver_router)
 app.include_router(spec_creation_router)

--- a/server/routers/__init__.py
+++ b/server/routers/__init__.py
@@ -6,6 +6,7 @@ FastAPI routers for different API endpoints.
 """
 
 from .agent import router as agent_router
+from .agent_sessions import router as agent_sessions_router
 from .assistant_chat import router as assistant_chat_router
 from .devserver import router as devserver_router
 from .expand_project import router as expand_project_router
@@ -21,6 +22,7 @@ __all__ = [
     "projects_router",
     "features_router",
     "agent_router",
+    "agent_sessions_router",
     "schedules_router",
     "devserver_router",
     "spec_creation_router",

--- a/server/routers/agent_sessions.py
+++ b/server/routers/agent_sessions.py
@@ -1,0 +1,88 @@
+"""
+Agent Sessions Router
+=====================
+
+REST API endpoints for querying persisted agent session logs.
+"""
+
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException, Query
+
+from ..services.agent_session_database import (
+    delete_session,
+    get_session_detail,
+    get_session_logs,
+    get_sessions,
+)
+from ..utils.project_helpers import get_project_path as _get_project_path
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/projects", tags=["agent-sessions"])
+
+
+def _resolve_project_dir(project_name: str):
+    """Resolve project directory or raise 404."""
+    project_dir = _get_project_path(project_name)
+    if not project_dir:
+        raise HTTPException(status_code=404, detail="Project not found")
+    return project_dir
+
+
+@router.get("/{project_name}/sessions")
+async def list_sessions(
+    project_name: str,
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+):
+    """List agent sessions for a project."""
+    project_dir = _resolve_project_dir(project_name)
+    sessions = get_sessions(project_dir, project_name, limit=limit, offset=offset)
+    return {"sessions": sessions}
+
+
+@router.get("/{project_name}/sessions/{session_id}")
+async def get_session(project_name: str, session_id: int):
+    """Get a single agent session."""
+    project_dir = _resolve_project_dir(project_name)
+    session = get_session_detail(project_dir, session_id)
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found")
+    return session
+
+
+@router.get("/{project_name}/sessions/{session_id}/logs")
+async def list_session_logs(
+    project_name: str,
+    session_id: int,
+    line_type: Optional[str] = Query(None),
+    feature_id: Optional[int] = Query(None),
+    limit: int = Query(500, ge=1, le=5000),
+    offset: int = Query(0, ge=0),
+):
+    """Get logs for an agent session with optional filters."""
+    project_dir = _resolve_project_dir(project_name)
+    # Verify session exists
+    session = get_session_detail(project_dir, session_id)
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found")
+    logs = get_session_logs(
+        project_dir, session_id,
+        line_type_filter=line_type,
+        feature_id_filter=feature_id,
+        limit=limit,
+        offset=offset,
+    )
+    return {"logs": logs}
+
+
+@router.delete("/{project_name}/sessions/{session_id}")
+async def remove_session(project_name: str, session_id: int):
+    """Delete an agent session and all its logs."""
+    project_dir = _resolve_project_dir(project_name)
+    deleted = delete_session(project_dir, session_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Session not found")
+    return {"success": True}

--- a/server/routers/settings.py
+++ b/server/routers/settings.py
@@ -113,6 +113,7 @@ async def get_settings():
         testing_agent_ratio=_parse_int(all_settings.get("testing_agent_ratio"), 1),
         playwright_headless=_parse_bool(all_settings.get("playwright_headless"), default=True),
         batch_size=_parse_int(all_settings.get("batch_size"), 3),
+        agent_session_logging=_parse_bool(all_settings.get("agent_session_logging"), default=True),
         api_provider=api_provider,
         api_base_url=all_settings.get("api_base_url"),
         api_has_auth_token=bool(all_settings.get("api_auth_token")),
@@ -137,6 +138,9 @@ async def update_settings(update: SettingsUpdate):
 
     if update.batch_size is not None:
         set_setting("batch_size", str(update.batch_size))
+
+    if update.agent_session_logging is not None:
+        set_setting("agent_session_logging", "true" if update.agent_session_logging else "false")
 
     # API provider settings
     if update.api_provider is not None:
@@ -177,6 +181,7 @@ async def update_settings(update: SettingsUpdate):
         testing_agent_ratio=_parse_int(all_settings.get("testing_agent_ratio"), 1),
         playwright_headless=_parse_bool(all_settings.get("playwright_headless"), default=True),
         batch_size=_parse_int(all_settings.get("batch_size"), 3),
+        agent_session_logging=_parse_bool(all_settings.get("agent_session_logging"), default=True),
         api_provider=api_provider,
         api_base_url=all_settings.get("api_base_url"),
         api_has_auth_token=bool(all_settings.get("api_auth_token")),

--- a/server/schemas.py
+++ b/server/schemas.py
@@ -419,6 +419,7 @@ class SettingsResponse(BaseModel):
     testing_agent_ratio: int = 1  # Regression testing agents (0-3)
     playwright_headless: bool = True
     batch_size: int = 3  # Features per coding agent batch (1-3)
+    agent_session_logging: bool = True  # Persist agent output to SQLite
     api_provider: str = "claude"
     api_base_url: str | None = None
     api_has_auth_token: bool = False  # Never expose actual token
@@ -438,6 +439,7 @@ class SettingsUpdate(BaseModel):
     testing_agent_ratio: int | None = None  # 0-3
     playwright_headless: bool | None = None
     batch_size: int | None = None  # Features per agent batch (1-3)
+    agent_session_logging: bool | None = None
     api_provider: str | None = None
     api_base_url: str | None = Field(None, max_length=500)
     api_auth_token: str | None = Field(None, max_length=500)  # Write-only, never returned

--- a/server/services/agent_session_database.py
+++ b/server/services/agent_session_database.py
@@ -1,0 +1,338 @@
+"""
+Agent Session Database
+======================
+
+SQLAlchemy models and functions for persisting agent session output.
+Each project has its own agent_sessions.db file in the project directory.
+"""
+
+import logging
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Index, Integer, String, Text, create_engine, event
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import DeclarativeBase, relationship, sessionmaker
+
+logger = logging.getLogger(__name__)
+
+
+class Base(DeclarativeBase):
+    """SQLAlchemy 2.0 style declarative base."""
+    pass
+
+
+# Engine cache to avoid creating new engines for each request
+_engine_cache: dict[str, Engine] = {}
+_cache_lock = threading.Lock()
+
+
+def _utc_now() -> datetime:
+    """Return current UTC time."""
+    return datetime.now(timezone.utc)
+
+
+class AgentSession(Base):
+    """An agent session for a project."""
+    __tablename__ = "agent_sessions"
+
+    id = Column(Integer, primary_key=True, index=True)
+    project_name = Column(String(100), nullable=False, index=True)
+    started_at = Column(DateTime, nullable=False, default=_utc_now)
+    ended_at = Column(DateTime, nullable=True)
+    status = Column(String(20), nullable=False, default="running")  # running/completed/crashed
+    yolo_mode = Column(Boolean, nullable=False, default=False)
+    model = Column(String(100), nullable=True)
+    max_concurrency = Column(Integer, nullable=True)
+
+    logs = relationship("AgentSessionLog", back_populates="session", cascade="all, delete-orphan")
+
+
+class AgentSessionLog(Base):
+    """A single log line within an agent session."""
+    __tablename__ = "agent_session_logs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    session_id = Column(Integer, ForeignKey("agent_sessions.id"), nullable=False)
+    timestamp = Column(DateTime, nullable=False, default=_utc_now)
+    line_type = Column(String(20), nullable=False)  # output/tool_use/tool_result/agent_update/error
+    content = Column(Text, nullable=False)
+    feature_id = Column(Integer, nullable=True)
+    agent_index = Column(Integer, nullable=True)
+    agent_name = Column(String(20), nullable=True)
+
+    session = relationship("AgentSession", back_populates="logs")
+
+    __table_args__ = (
+        Index("ix_session_logs_session_timestamp", "session_id", "timestamp"),
+    )
+
+
+def _get_db_path(project_dir: Path) -> Path:
+    """Get the path to the agent sessions database for a project."""
+    from autoforge_paths import get_agent_sessions_db_path
+    return get_agent_sessions_db_path(project_dir)
+
+
+def get_engine(project_dir: Path) -> Engine:
+    """Get or create a SQLAlchemy engine for a project's agent sessions database."""
+    cache_key = project_dir.as_posix()
+
+    if cache_key in _engine_cache:
+        return _engine_cache[cache_key]
+
+    with _cache_lock:
+        if cache_key not in _engine_cache:
+            db_path = _get_db_path(project_dir)
+            db_url = f"sqlite:///{db_path.as_posix()}"
+            engine = create_engine(
+                db_url,
+                echo=False,
+                connect_args={
+                    "check_same_thread": False,
+                    "timeout": 30,
+                }
+            )
+
+            # Enable WAL mode for better concurrent read/write performance
+            @event.listens_for(engine, "connect")
+            def _set_wal_mode(dbapi_conn, connection_record):
+                cursor = dbapi_conn.cursor()
+                cursor.execute("PRAGMA journal_mode=WAL")
+                cursor.close()
+
+            Base.metadata.create_all(engine)
+            _engine_cache[cache_key] = engine
+            logger.debug("Created agent sessions database engine for %s", cache_key)
+
+            # Refresh .gitignore so existing projects pick up the new db entries
+            from autoforge_paths import ensure_autoforge_dir
+            ensure_autoforge_dir(project_dir)
+
+    return _engine_cache[cache_key]
+
+
+def dispose_engine(project_dir: Path) -> bool:
+    """Dispose of and remove the cached engine for a project."""
+    cache_key = project_dir.as_posix()
+
+    if cache_key in _engine_cache:
+        engine = _engine_cache.pop(cache_key)
+        engine.dispose()
+        logger.debug("Disposed agent sessions database engine for %s", cache_key)
+        return True
+
+    return False
+
+
+def get_session(project_dir: Path):
+    """Get a new database session for a project."""
+    engine = get_engine(project_dir)
+    Session = sessionmaker(bind=engine)
+    return Session()
+
+
+# ============================================================================
+# Session CRUD
+# ============================================================================
+
+def create_session(
+    project_dir: Path,
+    project_name: str,
+    yolo_mode: bool = False,
+    model: Optional[str] = None,
+    max_concurrency: Optional[int] = None,
+) -> int:
+    """Create a new agent session. Returns the session ID."""
+    db = get_session(project_dir)
+    try:
+        session = AgentSession(
+            project_name=project_name,
+            yolo_mode=yolo_mode,
+            model=model,
+            max_concurrency=max_concurrency,
+        )
+        db.add(session)
+        db.commit()
+        db.refresh(session)
+        logger.info("Created agent session %d for project %s", session.id, project_name)
+        return session.id
+    finally:
+        db.close()
+
+
+def end_session(project_dir: Path, session_id: int, status: str = "completed") -> None:
+    """Mark a session as ended."""
+    db = get_session(project_dir)
+    try:
+        session = db.query(AgentSession).filter(AgentSession.id == session_id).first()
+        if session:
+            session.ended_at = _utc_now()
+            session.status = status
+            db.commit()
+            logger.info("Ended agent session %d with status %s", session_id, status)
+    finally:
+        db.close()
+
+
+def add_log(
+    project_dir: Path,
+    session_id: int,
+    line_type: str,
+    content: str,
+    feature_id: Optional[int] = None,
+    agent_index: Optional[int] = None,
+    agent_name: Optional[str] = None,
+) -> None:
+    """Add a single log entry to a session."""
+    db = get_session(project_dir)
+    try:
+        log = AgentSessionLog(
+            session_id=session_id,
+            line_type=line_type,
+            content=content,
+            feature_id=feature_id,
+            agent_index=agent_index,
+            agent_name=agent_name,
+        )
+        db.add(log)
+        db.commit()
+    finally:
+        db.close()
+
+
+def add_logs_batch(project_dir: Path, session_id: int, logs: list[dict]) -> None:
+    """Bulk insert log entries for performance."""
+    if not logs:
+        return
+    db = get_session(project_dir)
+    try:
+        for log_data in logs:
+            log = AgentSessionLog(
+                session_id=session_id,
+                line_type=log_data["line_type"],
+                content=log_data["content"],
+                feature_id=log_data.get("feature_id"),
+                agent_index=log_data.get("agent_index"),
+                agent_name=log_data.get("agent_name"),
+            )
+            db.add(log)
+        db.commit()
+    finally:
+        db.close()
+
+
+def get_sessions(
+    project_dir: Path,
+    project_name: str,
+    limit: int = 50,
+    offset: int = 0,
+) -> list[dict]:
+    """Get sessions for a project, ordered by most recent first."""
+    db = get_session(project_dir)
+    try:
+        sessions = (
+            db.query(AgentSession)
+            .filter(AgentSession.project_name == project_name)
+            .order_by(AgentSession.started_at.desc())
+            .offset(offset)
+            .limit(limit)
+            .all()
+        )
+        return [
+            {
+                "id": s.id,
+                "project_name": s.project_name,
+                "started_at": s.started_at.isoformat() if s.started_at else None,
+                "ended_at": s.ended_at.isoformat() if s.ended_at else None,
+                "status": s.status,
+                "yolo_mode": s.yolo_mode,
+                "model": s.model,
+                "max_concurrency": s.max_concurrency,
+            }
+            for s in sessions
+        ]
+    finally:
+        db.close()
+
+
+def get_session_detail(project_dir: Path, session_id: int) -> Optional[dict]:
+    """Get a single session by ID."""
+    db = get_session(project_dir)
+    try:
+        session = db.query(AgentSession).filter(AgentSession.id == session_id).first()
+        if not session:
+            return None
+        return {
+            "id": session.id,
+            "project_name": session.project_name,
+            "started_at": session.started_at.isoformat() if session.started_at else None,
+            "ended_at": session.ended_at.isoformat() if session.ended_at else None,
+            "status": session.status,
+            "yolo_mode": session.yolo_mode,
+            "model": session.model,
+            "max_concurrency": session.max_concurrency,
+        }
+    finally:
+        db.close()
+
+
+def get_session_logs(
+    project_dir: Path,
+    session_id: int,
+    line_type_filter: Optional[str] = None,
+    feature_id_filter: Optional[int] = None,
+    limit: int = 500,
+    offset: int = 0,
+) -> list[dict]:
+    """Get logs for a session with optional filters."""
+    db = get_session(project_dir)
+    try:
+        query = (
+            db.query(AgentSessionLog)
+            .filter(AgentSessionLog.session_id == session_id)
+        )
+        if line_type_filter:
+            query = query.filter(AgentSessionLog.line_type == line_type_filter)
+        if feature_id_filter is not None:
+            query = query.filter(AgentSessionLog.feature_id == feature_id_filter)
+
+        logs = (
+            query
+            .order_by(AgentSessionLog.timestamp.asc())
+            .offset(offset)
+            .limit(limit)
+            .all()
+        )
+        return [
+            {
+                "id": log.id,
+                "session_id": log.session_id,
+                "timestamp": log.timestamp.isoformat() if log.timestamp else None,
+                "line_type": log.line_type,
+                "content": log.content,
+                "feature_id": log.feature_id,
+                "agent_index": log.agent_index,
+                "agent_name": log.agent_name,
+            }
+            for log in logs
+        ]
+    finally:
+        db.close()
+
+
+def delete_session(project_dir: Path, session_id: int) -> bool:
+    """Delete a session and all its logs."""
+    db = get_session(project_dir)
+    try:
+        session = db.query(AgentSession).filter(AgentSession.id == session_id).first()
+        if not session:
+            return False
+        db.delete(session)
+        db.commit()
+        logger.info("Deleted agent session %d", session_id)
+        return True
+    finally:
+        db.close()

--- a/server/websocket.py
+++ b/server/websocket.py
@@ -9,6 +9,7 @@ import asyncio
 import json
 import logging
 import re
+import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Set
@@ -21,6 +22,10 @@ from .services.dev_server_manager import get_devserver_manager
 from .services.process_manager import get_manager
 from .utils.project_helpers import get_project_path as _get_project_path
 from .utils.validation import is_valid_project_name as validate_project_name
+
+# Ensure root is on sys.path for registry import
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
 
 # Lazy imports
 _count_passing_tests = None
@@ -79,6 +84,146 @@ ORCHESTRATOR_PATTERNS = {
     'all_complete': re.compile(r'All features complete'),
     'blocked_features': re.compile(r'(\d+) blocked by dependencies'),
 }
+
+
+# Patterns for classifying log line types
+_TOOL_USE_PATTERN = re.compile(r'\[Tool:\s*\w+\]', re.I)
+_ERROR_PATTERN = re.compile(r'^(?:Error|Failed|Exception|Traceback)', re.I)
+
+
+def classify_line_type(line: str) -> str:
+    """Classify an output line into a log type."""
+    if _TOOL_USE_PATTERN.search(line):
+        return "tool_use"
+    if _ERROR_PATTERN.search(line):
+        return "error"
+    return "output"
+
+
+class SessionLogger:
+    """Buffers and persists agent session logs to SQLite.
+
+    Accumulates logs in memory and flushes periodically (every 50 lines or 2 seconds)
+    to avoid per-line INSERT overhead.
+    """
+
+    def __init__(self, project_dir: Path, project_name: str):
+        self.project_dir = project_dir
+        self.project_name = project_name
+        self.session_id: int | None = None
+        self._buffer: list[dict] = []
+        self._flush_task: asyncio.Task | None = None
+        self._enabled = True
+        self._buffer_limit = 50
+
+    def _is_logging_enabled(self) -> bool:
+        """Check global setting for session logging."""
+        try:
+            from registry import get_setting
+            value = get_setting("agent_session_logging", "true")
+            return (value or "true").lower() == "true"
+        except Exception:
+            return True
+
+    async def start_session(
+        self,
+        yolo_mode: bool = False,
+        model: str | None = None,
+        max_concurrency: int | None = None,
+    ) -> None:
+        """Create a new session in the database."""
+        self._enabled = self._is_logging_enabled()
+        if not self._enabled:
+            return
+        try:
+            from .services.agent_session_database import create_session
+            self.session_id = create_session(
+                self.project_dir,
+                self.project_name,
+                yolo_mode=yolo_mode,
+                model=model,
+                max_concurrency=max_concurrency,
+            )
+            # Start periodic flush
+            self._flush_task = asyncio.create_task(self._periodic_flush())
+        except Exception:
+            logger.warning("Failed to create agent session", exc_info=True)
+            self._enabled = False
+
+    async def end_session(self, status: str = "completed") -> None:
+        """Flush remaining buffer and mark session as ended."""
+        if self._flush_task:
+            self._flush_task.cancel()
+            try:
+                await self._flush_task
+            except asyncio.CancelledError:
+                pass
+            self._flush_task = None
+
+        await self._flush()
+
+        if not self._enabled or self.session_id is None:
+            return
+        try:
+            from .services.agent_session_database import end_session
+            end_session(self.project_dir, self.session_id, status)
+        except Exception:
+            logger.warning("Failed to end agent session", exc_info=True)
+        self.session_id = None
+
+    def add_log(
+        self,
+        line: str,
+        feature_id: int | None = None,
+        agent_index: int | None = None,
+        agent_name: str | None = None,
+    ) -> None:
+        """Add a log entry to the buffer."""
+        if not self._enabled or self.session_id is None:
+            return
+        self._buffer.append({
+            "line_type": classify_line_type(line),
+            "content": line,
+            "feature_id": feature_id,
+            "agent_index": agent_index,
+            "agent_name": agent_name,
+        })
+        if len(self._buffer) >= self._buffer_limit:
+            # Schedule a flush (non-blocking)
+            asyncio.ensure_future(self._flush())
+
+    def add_agent_update(self, update: dict) -> None:
+        """Add an agent_update entry to the buffer."""
+        if not self._enabled or self.session_id is None:
+            return
+        self._buffer.append({
+            "line_type": "agent_update",
+            "content": json.dumps(update),
+            "feature_id": update.get("featureId"),
+            "agent_index": update.get("agentIndex"),
+            "agent_name": update.get("agentName"),
+        })
+
+    async def _flush(self) -> None:
+        """Flush buffered logs to the database."""
+        if not self._buffer or self.session_id is None:
+            return
+        batch = self._buffer[:]
+        self._buffer.clear()
+        try:
+            from .services.agent_session_database import add_logs_batch
+            add_logs_batch(self.project_dir, self.session_id, batch)
+        except Exception:
+            logger.warning("Failed to flush session logs", exc_info=True)
+
+    async def _periodic_flush(self) -> None:
+        """Flush buffer every 2 seconds."""
+        try:
+            while True:
+                await asyncio.sleep(2)
+                await self._flush()
+        except asyncio.CancelledError:
+            pass
 
 
 class AgentTracker:
@@ -755,16 +900,20 @@ async def project_websocket(websocket: WebSocket, project_name: str):
     # Create orchestrator tracker for observability
     orchestrator_tracker = OrchestratorTracker()
 
+    # Create session logger for persisting agent output
+    session_logger = SessionLogger(project_dir, project_name)
+
     async def on_output(line: str):
         """Handle agent output - broadcast to this WebSocket."""
         try:
             # Extract feature ID from line if present
             feature_id = None
             agent_index = None
+            agent_name = None
             match = FEATURE_ID_PATTERN.match(line)
             if match:
                 feature_id = int(match.group(1))
-                agent_index, _ = await agent_tracker.get_agent_info(feature_id)
+                agent_index, agent_name = await agent_tracker.get_agent_info(feature_id)
 
             # Send the raw log line with optional feature/agent attribution
             log_msg: dict[str, str | int] = {
@@ -779,11 +928,15 @@ async def project_websocket(websocket: WebSocket, project_name: str):
 
             await websocket.send_json(log_msg)
 
+            # Persist log line to session database
+            session_logger.add_log(line, feature_id=feature_id, agent_index=agent_index, agent_name=agent_name)
+
             # Check if this line indicates agent activity (parallel mode)
             # and emit agent_update messages if so
             agent_update = await agent_tracker.process_line(line)
             if agent_update:
                 await websocket.send_json(agent_update)
+                session_logger.add_agent_update(agent_update)
 
             # Also check for orchestrator events and emit orchestrator_update messages
             orch_update = await orchestrator_tracker.process_line(line)
@@ -799,10 +952,22 @@ async def project_websocket(websocket: WebSocket, project_name: str):
                 "type": "agent_status",
                 "status": status,
             })
+
+            # Start session logging when agent begins running
+            if status == "running":
+                await session_logger.start_session(
+                    yolo_mode=agent_manager.yolo_mode,
+                    model=agent_manager.model,
+                    max_concurrency=agent_manager.max_concurrency,
+                )
+
             # Reset trackers when agent stops OR crashes to prevent ghost agents on restart
             if status in ("stopped", "crashed"):
                 await agent_tracker.reset()
                 await orchestrator_tracker.reset()
+                await session_logger.end_session(
+                    status="completed" if status == "stopped" else "crashed"
+                )
         except Exception:
             pass  # Connection may be closed
 
@@ -901,6 +1066,10 @@ async def project_websocket(websocket: WebSocket, project_name: str):
         # Unregister dev server callbacks
         devserver_manager.remove_output_callback(on_dev_output)
         devserver_manager.remove_status_callback(on_dev_status_change)
+
+        # Flush any remaining session logs on disconnect
+        if session_logger.session_id is not None:
+            await session_logger.end_session(status="completed")
 
         # Disconnect from manager
         await manager.disconnect(websocket, project_name)

--- a/ui/src/components/SettingsModal.tsx
+++ b/ui/src/components/SettingsModal.tsx
@@ -391,6 +391,24 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
               />
             </div>
 
+            {/* Session Logging Toggle */}
+            <div className="flex items-center justify-between">
+              <div className="space-y-0.5">
+                <Label htmlFor="session-logging" className="font-medium">
+                  Session Logging
+                </Label>
+                <p className="text-sm text-muted-foreground">
+                  Save agent output to database for review
+                </p>
+              </div>
+              <Switch
+                id="session-logging"
+                checked={settings.agent_session_logging}
+                onCheckedChange={() => updateSettings.mutate({ agent_session_logging: !settings.agent_session_logging })}
+                disabled={isSaving}
+              />
+            </div>
+
             {/* Regression Agents */}
             <div className="space-y-2">
               <Label className="font-medium">Regression Agents</Label>

--- a/ui/src/hooks/useProjects.ts
+++ b/ui/src/hooks/useProjects.ts
@@ -268,6 +268,7 @@ const DEFAULT_SETTINGS: Settings = {
   testing_agent_ratio: 1,
   playwright_headless: true,
   batch_size: 3,
+  agent_session_logging: true,
   api_provider: 'claude',
   api_base_url: null,
   api_has_auth_token: false,

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -553,6 +553,7 @@ export interface Settings {
   testing_agent_ratio: number  // Regression testing agents (0-3)
   playwright_headless: boolean
   batch_size: number  // Features per coding agent batch (1-3)
+  agent_session_logging: boolean  // Persist agent output to SQLite
   api_provider: string
   api_base_url: string | null
   api_has_auth_token: boolean
@@ -565,6 +566,7 @@ export interface SettingsUpdate {
   testing_agent_ratio?: number
   playwright_headless?: boolean
   batch_size?: number
+  agent_session_logging?: boolean
   api_provider?: string
   api_base_url?: string
   api_auth_token?: string


### PR DESCRIPTION
## Summary

- Persist agent output (LLM responses, tool invocations, errors) to a per-project `agent_sessions.db` so past sessions can be reviewed and debugged
- Controlled by a global "Session Logging" toggle in settings (default: on)
- Buffered writes in WebSocket (flush every 50 lines or 2s) to minimize I/O overhead

## Changes

- New `server/services/agent_session_database.py` with SQLAlchemy models and CRUD operations
- New `server/routers/agent_sessions.py` — REST API for GET/DELETE sessions and logs with filtering
- WebSocket integration for real-time log capture
- Settings toggle in UI and backend
- `.gitignore` auto-refreshed for existing projects on first use

## Test plan

- [ ] Start an agent session and verify logs appear in `agent_sessions.db`
- [ ] Toggle session logging off in settings and confirm no new logs are written
- [ ] Verify buffered writes flush correctly (50 lines or 2s timeout)
- [ ] Test REST endpoints: list sessions, get session logs, delete session
- [ ] Confirm `.gitignore` is updated for existing projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)