### PR TITLE
Add auth policy disclaimer and bump to 0.1.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 
 A long-running autonomous coding agent powered by the Claude Agent SDK. This tool can build complete applications over multiple sessions using a two-agent pattern (initializer + coding agent). Includes a React-based UI for monitoring progress in real-time.
 
+> [!WARNING]
+> **Authentication:** Anthropic's policy states that third-party developers may not offer `claude.ai` login or subscription-based rate limits for their products (including agents built on the Claude Agent SDK) unless previously approved. Using your Claude subscription with AutoForge may risk account suspension. We recommend using an API key from [console.anthropic.com](https://console.anthropic.com/) instead.
+
+> [!NOTE]
+> **This repository is no longer actively maintained.** Most agent coding tools now ship their own long-running harnesses, making this project less necessary. Feel free to fork and continue development on your own!
+
 ## Video Tutorial
 
 [![Watch the tutorial](https://img.youtube.com/vi/nKiPOxDpcJY/hqdefault.jpg)](https://youtu.be/nKiPOxDpcJY)
@@ -34,8 +40,8 @@ irm https://claude.ai/install.ps1 | iex
 
 You need one of the following:
 
-- **Claude Pro/Max Subscription** - Use `claude login` to authenticate (recommended)
-- **Anthropic API Key** - Pay-per-use from https://console.anthropic.com/
+- **Anthropic API Key** (recommended) - Pay-per-use from https://console.anthropic.com/
+- **Claude Pro/Max Subscription** - Use `claude login` to authenticate (see warning above)
 
 ---
 
@@ -101,7 +107,7 @@ This launches the React-based web UI at `http://localhost:5173` with:
 
 The start script will:
 1. Check if Claude CLI is installed
-2. Check if you're authenticated (prompt to run `claude login` if not)
+2. Check if you're authenticated (prompt to configure authentication if not)
 3. Create a Python virtual environment
 4. Install dependencies
 5. Launch the main menu
@@ -371,7 +377,7 @@ Edit `security.py` to add or remove commands from `ALLOWED_COMMANDS`.
 Install the Claude Code CLI using the instructions in the Prerequisites section.
 
 **"Not authenticated with Claude"**
-Run `claude login` to authenticate. The start script will prompt you to do this automatically.
+Set your API key via `ANTHROPIC_API_KEY` environment variable or the Settings UI. Alternatively, run `claude login` to use subscription credentials, but note that Anthropic's policy may not permit subscription-based auth for third-party agents.
 
 **"Appears to hang on first run"**
 This is normal. The initializer agent is generating detailed test cases, which takes significant time. Watch for `[Tool: ...]` output to confirm the agent is working.

--- a/auth.py
+++ b/auth.py
@@ -53,11 +53,16 @@ AUTH_ERROR_HELP_CLI = """
 
 Claude CLI requires authentication to work.
 
-To fix this, run:
+Option 1 (Recommended): Set an API key
+  export ANTHROPIC_API_KEY=your-key-here
+  Get a key at: https://console.anthropic.com/
+
+Option 2: Use subscription login
   claude login
 
-This will open a browser window to sign in.
-After logging in, try running this command again.
+  Note: Anthropic's policy may not permit using
+  subscription auth with third-party agents.
+  API key authentication is recommended.
 ==================================================
 """
 
@@ -69,11 +74,16 @@ AUTH_ERROR_HELP_SERVER = """
 
 Claude CLI requires authentication to work.
 
-To fix this, run:
+Option 1 (Recommended): Set an API key
+  export ANTHROPIC_API_KEY=your-key-here
+  Get a key at: https://console.anthropic.com/
+
+Option 2: Use subscription login
   claude login
 
-This will open a browser window to sign in.
-After logging in, try starting the agent again.
+  Note: Anthropic's policy may not permit using
+  subscription auth with third-party agents.
+  API key authentication is recommended.
 ================================================================================
 """
 

--- a/autonomous_agent_demo.py
+++ b/autonomous_agent_demo.py
@@ -76,8 +76,8 @@ Examples:
   python autonomous_agent_demo.py --project-dir my-app --testing-ratio 0
 
 Authentication:
-  Uses Claude CLI authentication (run 'claude login' if not logged in)
-  Authentication is handled by start.bat/start.sh before this runs
+  Uses Claude CLI authentication. API key (ANTHROPIC_API_KEY) is recommended.
+  Alternatively run 'claude login', but note Anthropic's policy may restrict subscription auth.
         """,
     )
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autoforge-ai",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Autonomous coding agent with web UI - build complete apps with AI",
   "license": "AGPL-3.0",
   "bin": {

--- a/start.bat
+++ b/start.bat
@@ -29,11 +29,12 @@ REM verify the CLI is installed and remind the user to login if needed
 set "CLAUDE_DIR=%USERPROFILE%\.claude"
 if exist "%CLAUDE_DIR%\" (
     echo [OK] Claude CLI directory found
-    echo      ^(If you're not logged in, run: claude login^)
+    echo      ^(Set ANTHROPIC_API_KEY or run: claude login^)
 ) else (
     echo [!] Claude CLI not configured
     echo.
-    echo Please run 'claude login' to authenticate before continuing.
+    echo Please set ANTHROPIC_API_KEY or run 'claude login' to authenticate.
+    echo Note: API key auth is recommended. See README for details.
     echo.
     pause
 )

--- a/start.py
+++ b/start.py
@@ -255,7 +255,7 @@ def run_spec_creation(project_dir: Path) -> bool:
             print(f"Please ensure app_spec.txt exists in: {get_project_prompts_dir(project_dir)}")
             # If failed with non-zero exit and no spec, might be auth issue
             if result.returncode != 0:
-                print("\nIf you're having authentication issues, try running: claude login")
+                print("\nIf you're having authentication issues, set ANTHROPIC_API_KEY or try: claude login")
             return False
 
     except FileNotFoundError:
@@ -416,7 +416,7 @@ def run_agent(project_name: str, project_dir: Path) -> None:
                 print(f"\nAgent error:\n{stderr_output.strip()}")
                 # Still hint about auth if exit was unexpected
                 if "error" in stderr_output.lower() or "exception" in stderr_output.lower():
-                    print("\nIf this is an authentication issue, try running: claude login")
+                    print("\nIf this is an authentication issue, set ANTHROPIC_API_KEY or try: claude login")
 
     except KeyboardInterrupt:
         print("\n\nAgent interrupted. Run again to resume.")

--- a/start.sh
+++ b/start.sh
@@ -25,11 +25,12 @@ echo "[OK] Claude CLI found"
 # verify the CLI is installed and remind the user to login if needed
 if [ -d "$HOME/.claude" ]; then
     echo "[OK] Claude CLI directory found"
-    echo "     (If you're not logged in, run: claude login)"
+    echo "     (Set ANTHROPIC_API_KEY or run: claude login)"
 else
     echo "[!] Claude CLI not configured"
     echo ""
-    echo "Please run 'claude login' to authenticate before continuing."
+    echo "Please set ANTHROPIC_API_KEY or run 'claude login' to authenticate."
+    echo "Note: API key auth is recommended. See README for details."
     echo ""
     read -p "Press Enter to continue anyway, or Ctrl+C to exit..."
 fi

--- a/start_ui.sh
+++ b/start_ui.sh
@@ -16,16 +16,16 @@ if ! command -v claude &> /dev/null; then
     echo "    The agent requires Claude CLI to work."
     echo "    Install it from: https://claude.ai/download"
     echo ""
-    echo "    After installing, run: claude login"
+    echo "    After installing, set ANTHROPIC_API_KEY or run: claude login"
     echo ""
 else
     echo "[OK] Claude CLI found"
     # Note: Claude CLI no longer stores credentials in ~/.claude/.credentials.json
     # We can't reliably check auth status without making an API call
     if [ -d "$HOME/.claude" ]; then
-        echo "     (If you're not logged in, run: claude login)"
+        echo "     (Set ANTHROPIC_API_KEY or run: claude login)"
     else
-        echo "[!] Claude CLI not configured - run 'claude login' first"
+        echo "[!] Claude CLI not configured - set ANTHROPIC_API_KEY or run 'claude login'"
     fi
 fi
 echo ""

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -56,7 +56,7 @@
     },
     "..": {
       "name": "autoforge-ai",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "license": "AGPL-3.0",
       "bin": {
         "autoforge": "bin/autoforge.js"

--- a/ui/src/components/SettingsModal.tsx
+++ b/ui/src/components/SettingsModal.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Loader2, AlertCircle, Check, Moon, Sun, Eye, EyeOff, ShieldCheck } from 'lucide-react'
+import { Loader2, AlertCircle, AlertTriangle, Check, Moon, Sun, Eye, EyeOff, ShieldCheck } from 'lucide-react'
 import { useSettings, useUpdateSettings, useAvailableModels, useAvailableProviders } from '../hooks/useProjects'
 import { useTheme, THEMES } from '../hooks/useTheme'
 import type { ProviderInfo } from '../lib/types'
@@ -21,7 +21,7 @@ interface SettingsModalProps {
 }
 
 const PROVIDER_INFO_TEXT: Record<string, string> = {
-  claude: 'Default provider. Uses your Claude CLI credentials.',
+  claude: 'Default provider. Uses Claude CLI credentials. API key auth is recommended.',
   kimi: 'Get an API key at kimi.com',
   glm: 'Get an API key at open.bigmodel.cn',
   ollama: 'Run models locally. Install from ollama.com',
@@ -244,6 +244,15 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
               <p className="text-xs text-muted-foreground">
                 {PROVIDER_INFO_TEXT[currentProvider] ?? ''}
               </p>
+
+              {currentProvider === 'claude' && (
+                <Alert className="border-amber-500/50 bg-amber-50 dark:bg-amber-950/20 mt-2">
+                  <AlertTriangle className="h-4 w-4 text-amber-600" />
+                  <AlertDescription className="text-xs text-amber-700 dark:text-amber-300">
+                    Anthropic's policy may not permit using subscription-based auth (<code className="text-xs">claude login</code>) with third-party agents. Consider using an API key provider or setting the <code className="text-xs">ANTHROPIC_API_KEY</code> environment variable to avoid potential account issues.
+                  </AlertDescription>
+                </Alert>
+              )}
 
               {/* Auth Token Field */}
               {showAuthField && (


### PR DESCRIPTION
## Summary
- Add prominent warnings about Anthropic's Agent SDK policy on subscription-based auth for third-party agents (README, Settings UI, start scripts, error messages)
- Flip recommended auth method from `claude login` to API key (`ANTHROPIC_API_KEY`)
- Add repo maintenance notice (no longer actively maintained, feel free to fork)
- Version bump to 0.1.19

## Test plan
- [ ] Verify README renders correctly on GitHub (WARNING and NOTE admonition boxes)
- [ ] Open Settings modal → Claude provider selected → amber warning alert visible
- [ ] Run `ruff check .` — passes
- [ ] Run `python test_security.py` — 169/169 pass
- [ ] Run `cd ui && npm run lint && npm run build` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)